### PR TITLE
#64-Farbe der Kachel im Dashboard

### DIFF
--- a/src/components/kpiBox.vue
+++ b/src/components/kpiBox.vue
@@ -33,9 +33,9 @@ export default {
     const co2Class = computed(() => {
       console.log('aaaaCO2:', props.kpi.co2);
       
-      if (props.kpi.co2 > 0 && props.kpi.co2 < 150) {
+      if (props.kpi.co2 > 0 && props.kpi.co2 < 300) {
         return 'green';
-      } else if (props.kpi.co2 >= 150 && props.kpi.co2 < 300) {
+      } else if (props.kpi.co2 >= 300 && props.kpi.co2 < 500) {
         return 'yellow';
       } else if (props.kpi.co2 <= 0) {
         return 'grey';

--- a/src/components/kpiBox.vue
+++ b/src/components/kpiBox.vue
@@ -1,6 +1,7 @@
 <template>
-  <div class="dashboard-item" :class="{ hidden: !kpi.visible }" @click="openPhaseView">
-    <div class="dashboard-item__content" :class="co2Class">
+  <div :class="['dashboard-item', co2Class]" @click="openPhaseView">
+    <div :class="{ hidden: !kpi.visible }">
+    <div class="dashboard-item__content">
       <h3 class="dashboard-item__heading">
         <slot name="heading" />
       </h3>
@@ -8,7 +9,8 @@
         <slot name="content" />
       </div>
     </div>
-    <button class="dashboard-item__button" @click="$emit('toggle-visibility')">X</button>
+    <button class="dashboard-item__button" @click.stop="$emit('toggle-visibility')">X</button>
+  </div>
   </div>
 </template>
 
@@ -29,10 +31,14 @@ export default {
   },
   setup(props) {
     const co2Class = computed(() => {
-      if (props.kpi.co2 < 150) {
+      console.log('aaaaCO2:', props.kpi.co2);
+      
+      if (props.kpi.co2 > 0 && props.kpi.co2 < 150) {
         return 'green';
-      } else if (props.kpi.co2 >= 150 && props.kpi.co2 < 800) {
+      } else if (props.kpi.co2 >= 150 && props.kpi.co2 < 300) {
         return 'yellow';
+      } else if (props.kpi.co2 <= 0) {
+        return 'grey';
       } else {
         return 'red';
       }
@@ -55,8 +61,8 @@ export default {
   width: 30%;
   height: 200px; /* Fix height for all cards */
   margin-top: 2rem;
-  border: 2px solid grey;
-  border-radius: 2px;
+  border: 0.5px solid;
+  border-radius: 10px;
   box-sizing: border-box;
   padding: 1rem;
   visibility: visible;
@@ -68,6 +74,29 @@ export default {
 .dashboard-item.hidden {
   visibility: hidden;
   opacity: 0;
+}
+.green {
+  background-color: #BFE3A9;
+  border-color: #BFE3A9;
+  /* color: white; */
+}
+
+.yellow {
+  background-color: #FFD378;
+  border-color: #FFD378;
+  /* color: black; */
+}
+
+.red {
+  background-color: #FF8A84;
+  border-color: #FF8A84;
+  /* color: white; */
+}
+
+.grey {
+  background-color: #EEEFEE;
+  border-color: #EEEFEE;
+  /* color: white; */
 }
 
 .dashboard-item__content {
@@ -81,21 +110,6 @@ export default {
   margin-right: 1rem;
   padding-right: 2rem;
   padding-top: 2rem;
-}
-
-.green .dashboard-item__content {
-  background-color: green;
-  color: white;
-}
-
-.yellow .dashboard-item__content {
-  background-color: yellow;
-  color: black;
-}
-
-.red .dashboard-item__content {
-  background-color: red;
-  color: white;
 }
 
 .dashboard-item__heading {
@@ -115,8 +129,9 @@ export default {
   position: absolute;
   top: 0;
   right: 0;
-  background: var(--color-background);
-  color: var(--color-text);
+  background: inherit;
+  color: black;
+  font-style: oblique;
   border: 0;
   padding: 0.5rem;
   border-radius: 2px;

--- a/src/components/kpiBox.vue
+++ b/src/components/kpiBox.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="dashboard-item" :class="{ hidden: !kpi.visible }" @click="openPhaseView">
-    <div class="dashboard-item__content">
+    <div class="dashboard-item__content" :class="co2Class">
       <h3 class="dashboard-item__heading">
         <slot name="heading" />
       </h3>
@@ -13,9 +13,7 @@
 </template>
 
 <script lang="ts">
-// defineProps({
-//   kpi: Object
-// });
+import { computed } from 'vue';
 
 export default {
   props: {
@@ -28,7 +26,22 @@ export default {
     openPhaseView() {
       this.$router.push({ name: 'Phase' })
     }
-  }
+  },
+  setup(props) {
+    const co2Class = computed(() => {
+      if (props.kpi.co2 < 150) {
+        return 'green';
+      } else if (props.kpi.co2 >= 150 && props.kpi.co2 < 800) {
+        return 'yellow';
+      } else {
+        return 'red';
+      }
+    });
+
+    return {
+      co2Class,
+    };
+  },
 }
 
 </script>
@@ -68,6 +81,21 @@ export default {
   margin-right: 1rem;
   padding-right: 2rem;
   padding-top: 2rem;
+}
+
+.green .dashboard-item__content {
+  background-color: green;
+  color: white;
+}
+
+.yellow .dashboard-item__content {
+  background-color: yellow;
+  color: black;
+}
+
+.red .dashboard-item__content {
+  background-color: red;
+  color: white;
 }
 
 .dashboard-item__heading {


### PR DESCRIPTION
Was wurde geändert:
- Farbe der Kachel im Component KpiBox.vue wurde nach [diesem Ticket ](https://gitlab.rz.htw-berlin.de/brajko/nachhaltigkeits-dashboard/-/issues/64/?work_item_iid=87)implementiert.

<img width="1786" alt="Screenshot 2024-07-11 at 20 07 43" src="https://github.com/mesyamaureen/nachhaltigkeits-dashboard-frontend/assets/64224796/1251dc75-0d4b-4f18-8907-3c52afdb6011">

