### PR TITLE
Keep kpi after reload

### DIFF
--- a/src/components/AddKpiPopup.vue
+++ b/src/components/AddKpiPopup.vue
@@ -21,21 +21,27 @@
 import { ref } from 'vue';
 import { defineProps, defineEmits } from 'vue';
 
-const props = defineProps({
-  show: Boolean,
-  kpi: Array
-});
+interface Kpi {
+  id: number;
+  name: string;
+  co2: number;
+}
+
+const props = defineProps<{
+  show: boolean;
+  kpi: Kpi[];
+}>();
 
 const emits = defineEmits(['close', 'confirm']);
 
-const selectedKpi = ref(null);
+const selectedKpi = ref<number | null>(null);
 
 const closePopup = () => {
   emits('close');
 };
 
 const confirmSelection = () => {
-  if (selectedKpi.value) {
+  if (selectedKpi.value !== null) {
     emits('confirm', selectedKpi.value);
   } else {
     alert('Bitte wählen Sie eine KPI aus.');

--- a/src/components/AddKpiPopup.vue
+++ b/src/components/AddKpiPopup.vue
@@ -6,7 +6,7 @@
       <div class="form-group">
         <label for="kpi-select">Wählen Sie eine KPI aus:</label>
         <select id="kpi-select" v-model="selectedKpi">
-          <option v-for="k in kpi as any" :key="k.id" :value="k.id">
+          <option v-for="k in kpi" :key="k.id" :value="k.id">
             {{ k.name }}
           </option>
         </select>

--- a/src/components/kpiBox.vue
+++ b/src/components/kpiBox.vue
@@ -58,7 +58,7 @@ export default {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  width: 300px;
+  width: 450px;
   height: 200px; /* Fix height for all cards */
   margin-top: 2rem;
   border: 0.5px solid;

--- a/src/components/kpiBox.vue
+++ b/src/components/kpiBox.vue
@@ -9,7 +9,7 @@
         <slot name="content" />
       </div>
     </div>
-    <button class="dashboard-item__button" @click.stop="$emit('toggle-visibility')">X</button>
+    <button class="dashboard-item__button" @click.stop="$emit('remove-kpi', kpi.id)">X</button>
   </div>
   </div>
 </template>
@@ -58,7 +58,7 @@ export default {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  width: 30%;
+  width: 300px;
   height: 200px; /* Fix height for all cards */
   margin-top: 2rem;
   border: 0.5px solid;

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -5,7 +5,7 @@ import { fetchKpi } from '@/api/api.js';
 import kpiBox from '@/components/kpiBox.vue'
 import AddKpiPopup from '@/components/AddKpiPopup.vue';
 
-const kpi: any = ref([]);
+const kpi = ref([]);
 const showPopup = ref(false);
 
 const openPopup = () => {
@@ -19,26 +19,26 @@ const closePopup = () => {
 const loadKpi = async () => {
   try {
     const fetchedKpi = await fetchKpi();
-    kpi.value = fetchedKpi.map((kpiItem: any) => ({ ...kpiItem, visible: true }));
+    kpi.value = fetchedKpi.map((kpiItem: any) => ({ ...kpiItem }));
     kpi.value.forEach((kpiItem: any) => {
-      console.log(`KPI ID: ${kpiItem.id}, Visible: ${kpiItem.visible}`); // Debugging-Ausgabe
+      console.log(`KPI ID: ${kpiItem.id}`); // Debugging-Ausgabe
     });
   } catch (error) {
     console.error('Failed to load KPIs:', error);
   }
 };
 
-const toggleKpiVisibility = (kpiId: any) => {
-  const kpiItem: any = kpi.value.find((kpi: any) => kpi.id === kpiId);
-  if (kpiItem) {
-    kpiItem.visible = !kpiItem.visible;
-    console.log(`KPI ID: ${kpiId}, Visible: ${kpiItem.visible}`); // Debugging-Ausgabe
-  }
+const removeKpi = (kpiId: any) => {
+  kpi.value = kpi.value.filter((kpi: any) => kpi.id !== kpiId);
+  console.log(`KPI ID: ${kpiId} removed`); // Debugging-Ausgabe
 };
 
 const confirmSelection = (kpiId: any) => {
-  toggleKpiVisibility(kpiId);
-  closePopup();
+  const selectedKpi = kpi.value.find((kpi: any) => kpi.id === kpiId);
+  if (selectedKpi) {
+    kpi.value.push(selectedKpi);
+    closePopup();
+  }
 };
 
 onMounted(() => {
@@ -53,14 +53,14 @@ onMounted(() => {
       <button class="circle-button" @click="openPopup">+</button>
     </div>
 
-    <AddKpiPopup :show="showPopup" :kpi="kpi.filter((kpiItem: any) => !kpiItem.visible)" @close="closePopup" @confirm="confirmSelection" />
+    <AddKpiPopup :show="showPopup" :kpi="kpi" @close="closePopup" @confirm="confirmSelection" />
 
     <div class="items">
       <kpiBox
         v-for="(kpiItem, index) in kpi"
         :key="index"
         :kpi="kpiItem"
-        @toggle-visibility="toggleKpiVisibility(kpiItem.id)">
+        @remove-kpi="removeKpi(kpiItem.id)">
         <template #heading>{{ kpiItem.name }}</template>
         <template #content>
           {{ kpiItem.co2 }} Co² Verbrauch

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -1,3 +1,27 @@
+<template>
+  <main class="content">
+    <div class="title">
+      <h1>Übersicht</h1>
+      <button class="circle-button" @click="openPopup">+</button>
+    </div>
+
+    <AddKpiPopup :show="showPopup" :kpi="availableKpi" @close="closePopup" @confirm="confirmSelection" />
+
+    <div class="items">
+      <kpiBox
+        v-for="(kpiItem, index) in kpi"
+        :key="index"
+        :kpi="kpiItem"
+        @remove-kpi="removeKpi(kpiItem.id)">
+        <template #heading>{{ kpiItem.name }}</template>
+        <template #content>
+          {{ kpiItem.co2 }} Co² Verbrauch
+        </template>
+      </kpiBox>
+    </div>
+  </main>
+</template>
+
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue';
 // @ts-ignore
@@ -67,30 +91,6 @@ onMounted(() => {
   loadKpi();
 });
 </script>
-
-<template>
-  <main class="content">
-    <div class="title">
-      <h1>Übersicht</h1>
-      <button class="circle-button" @click="openPopup">+</button>
-    </div>
-
-    <AddKpiPopup :show="showPopup" :kpi="availableKpi" @close="closePopup" @confirm="confirmSelection" />
-
-    <div class="items">
-      <kpiBox
-        v-for="(kpiItem, index) in kpi"
-        :key="index"
-        :kpi="kpiItem"
-        @remove-kpi="removeKpi(kpiItem.id)">
-        <template #heading>{{ kpiItem.name }}</template>
-        <template #content>
-          {{ kpiItem.co2 }} Co² Verbrauch
-        </template>
-      </kpiBox>
-    </div>
-  </main>
-</template>
 
 <style scoped>
 header {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -1,51 +1,3 @@
-<script setup lang="ts">
-import { ref, onMounted } from 'vue';
-// @ts-ignore
-import { fetchKpi } from '@/api/api.js';
-import kpiBox from '@/components/kpiBox.vue'
-import AddKpiPopup from '@/components/AddKpiPopup.vue';
-
-const kpi = ref([]);
-const showPopup = ref(false);
-
-const openPopup = () => {
-  showPopup.value = true;
-};
-
-const closePopup = () => {
-  showPopup.value = false;
-};
-
-const loadKpi = async () => {
-  try {
-    const fetchedKpi = await fetchKpi();
-    kpi.value = fetchedKpi.map((kpiItem: any) => ({ ...kpiItem }));
-    kpi.value.forEach((kpiItem: any) => {
-      console.log(`KPI ID: ${kpiItem.id}`); // Debugging-Ausgabe
-    });
-  } catch (error) {
-    console.error('Failed to load KPIs:', error);
-  }
-};
-
-const removeKpi = (kpiId: any) => {
-  kpi.value = kpi.value.filter((kpi: any) => kpi.id !== kpiId);
-  console.log(`KPI ID: ${kpiId} removed`); // Debugging-Ausgabe
-};
-
-const confirmSelection = (kpiId: any) => {
-  const selectedKpi = kpi.value.find((kpi: any) => kpi.id === kpiId);
-  if (selectedKpi) {
-    kpi.value.push(selectedKpi);
-    closePopup();
-  }
-};
-
-onMounted(() => {
-  loadKpi();
-});
-</script>
-
 <template>
   <main class="content">
     <div class="title">
@@ -53,7 +5,7 @@ onMounted(() => {
       <button class="circle-button" @click="openPopup">+</button>
     </div>
 
-    <AddKpiPopup :show="showPopup" :kpi="kpi" @close="closePopup" @confirm="confirmSelection" />
+    <AddKpiPopup :show="showPopup" :kpi="availableKpi" @close="closePopup" @confirm="confirmSelection" />
 
     <div class="items">
       <kpiBox
@@ -69,6 +21,60 @@ onMounted(() => {
     </div>
   </main>
 </template>
+
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue';
+// @ts-ignore
+import { fetchKpi } from '@/api/api.js';
+import kpiBox from '@/components/kpiBox.vue';
+import AddKpiPopup from '@/components/AddKpiPopup.vue';
+
+const kpi = ref([]);
+const allKpi = ref([]);
+const showPopup = ref(false);
+
+const openPopup = () => {
+  showPopup.value = true;
+};
+
+const closePopup = () => {
+  showPopup.value = false;
+};
+
+const loadKpi = async () => {
+  try {
+    const fetchedKpi = await fetchKpi();
+    allKpi.value = fetchedKpi.map((kpiItem: any) => ({ ...kpiItem }));
+    kpi.value.forEach((kpiItem: any) => {
+      console.log(`KPI ID: ${kpiItem.id}`); // Debugging-Ausgabe
+    });
+  } catch (error) {
+    console.error('Failed to load KPIs:', error);
+  }
+};
+
+const removeKpi = (kpiId: any) => {
+  kpi.value = kpi.value.filter((kpiItem: any) => kpiItem.id !== kpiId);
+  console.log(`KPI ID: ${kpiId} removed`); // Debugging-Ausgabe
+};
+
+const confirmSelection = (kpiId: any) => {
+  const selectedKpi = allKpi.value.find((kpiItem: any) => kpiItem.id === kpiId);
+  if (selectedKpi) {
+    kpi.value.push(selectedKpi);
+    closePopup();
+  }
+};
+
+const availableKpi = computed(() => {
+  const selectedIds = kpi.value.map((kpiItem: any) => kpiItem.id);
+  return allKpi.value.filter((kpiItem: any) => !selectedIds.includes(kpiItem.id));
+});
+
+onMounted(() => {
+  loadKpi();
+});
+</script>
 
 <style scoped>
 header {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -59,7 +59,10 @@ const loadKpi = async () => {
 
 const loadSelectedKpi = () => {
   const selectedKpiIds = JSON.parse(localStorage.getItem('selectedKpi') || '[]');
-  kpi.value = allKpi.value.filter((kpiItem: Kpi) => selectedKpiIds.includes(kpiItem.id));
+  const selectedKpi = allKpi.value.filter((kpiItem: Kpi) => selectedKpiIds.includes(kpiItem.id));
+  // Sortiere die ausgewählten KPIs nach ID, um eine konsistente Reihenfolge zu gewährleisten
+  selectedKpi.sort((a, b) => selectedKpiIds.indexOf(a.id) - selectedKpiIds.indexOf(b.id));
+  kpi.value = selectedKpi;
 };
 
 const saveSelectedKpi = () => {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -107,8 +107,8 @@ header {
 }
 
 .items {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
   margin-top: 2rem;
 }


### PR DESCRIPTION
Die gespeicherten KPIs werden nun auch nach dem neuladen der Seite weiterhin korrekt angezeigt, da diese im lokalen Speicher gespeichert werden 